### PR TITLE
Fix broken documentation links causing CI build failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,8 +364,8 @@ csp-cli update service-name
 | Guide | Purpose |
 |-------|----------|
 | **[📖 Contributing Guide](./CONTRIBUTING.md)** | Complete contribution workflow |
-| **[🏗️ Architecture Guide](./docs/ARCHITECTURE.md)** | Technical architecture and design |
-| **[🔧 Service Definition Guide](./docs/SERVICE_DEFINITION_GUIDE.md)** | How to create service definitions |
+| **[🏗️ Architecture Guide](./docs/maintainer/ARCHITECTURE.md)** | Technical architecture and design |
+| **[🔧 Service Definition Guide](./docs/maintainer/SERVICE_DEFINITION_GUIDE.md)** | How to create service definitions |
 | **[🚀 Development Setup](./CONTRIBUTING.md#quick-start)** | Local development environment |
 
 ### 🌟 **What We Need Most**

--- a/apps/docs/docusaurus.config.js
+++ b/apps/docs/docusaurus.config.js
@@ -76,11 +76,11 @@ const config = {
             items: [
               {
                 label: 'Architecture',
-                to: '/ARCHITECTURE',
+                to: '/maintainer/ARCHITECTURE',
               },
               {
                 label: 'Maintainer Guide',
-                to: '/MAINTAINER_GUIDE',
+                to: '/maintainer/MAINTAINER_GUIDE',
               },
             ],
           },

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -445,7 +445,7 @@ We believe in recognizing our contributors:
 
 ### Community Guidelines
 
-We follow the [Contributor Covenant Code of Conduct](https://github.com/eason-dev/csp-kit/blob/main/CODE_OF_CONDUCT.md). Please be:
+We follow the Contributor Covenant Code of Conduct. Please be:
 
 - **Respectful** and inclusive
 - **Constructive** in feedback
@@ -534,5 +534,5 @@ By contributing to CSP Kit:
 - **[Getting Started](./getting-started.md)** - Using CSP Kit
 - **[API Reference](./api-reference.md)** - Complete API docs
 - **[CLI Guide](./cli-guide.md)** - Command-line tools
-- **[Maintainer Architecture](./maintainer/architecture.md)** - Technical details
-- **[Service Definition Guide](./maintainer/service-definition-guide.md)** - Detailed schema docs
+- **[Maintainer Architecture](./maintainer/ARCHITECTURE.md)** - Technical details
+- **[Service Definition Guide](./maintainer/SERVICE_DEFINITION_GUIDE.md)** - Detailed schema docs

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -496,7 +496,7 @@ Understanding our release cycle helps with contribution timing:
 
 ## 🔮 Roadmap Alignment
 
-Check our [roadmap](https://github.com/eason-dev/csp-kit/blob/main/ROADMAP.md) to see how your contribution fits:
+Check our [roadmap](../ROADMAP.md) to see how your contribution fits:
 
 ### Current Focus Areas
 
@@ -523,7 +523,7 @@ Every contribution, no matter how small, makes CSP Kit better for everyone. Whet
 ### 📄 **License Agreement**
 
 By contributing to CSP Kit:
-- **Your contributions will be licensed under the [MIT License](https://github.com/eason-dev/csp-kit/blob/main/LICENSE)**
+- **Your contributions will be licensed under the [MIT License](../LICENSE)**
 - **🔓 Your contributions remain open source forever** - CSP Kit is committed to remaining free and open source software
 - **No copyright assignment required** - You retain rights to your contributions
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -496,7 +496,7 @@ Understanding our release cycle helps with contribution timing:
 
 ## 🔮 Roadmap Alignment
 
-Check our [roadmap](../ROADMAP.md) to see how your contribution fits:
+Check our [roadmap](https://github.com/eason-dev/csp-kit/blob/main/ROADMAP.md) to see how your contribution fits:
 
 ### Current Focus Areas
 
@@ -523,7 +523,7 @@ Every contribution, no matter how small, makes CSP Kit better for everyone. Whet
 ### 📄 **License Agreement**
 
 By contributing to CSP Kit:
-- **Your contributions will be licensed under the [MIT License](../LICENSE)**
+- **Your contributions will be licensed under the [MIT License](https://github.com/eason-dev/csp-kit/blob/main/LICENSE)**
 - **🔓 Your contributions remain open source forever** - CSP Kit is committed to remaining free and open source software
 - **No copyright assignment required** - You retain rights to your contributions
 

--- a/docs/examples/nextjs.md
+++ b/docs/examples/nextjs.md
@@ -657,7 +657,4 @@ if (process.env.NODE_ENV === 'development') {
 
 ## 🔗 Related Examples
 
-- **[Express.js Integration](./express.md)**
-- **[React Integration](./react.md)**
-- **[Vue.js Integration](./vue.md)**
-- **[Nuxt.js Integration](./nuxt.md)**
+*More framework examples coming soon! Contributions welcome.*

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -277,7 +277,7 @@ Now that you're up and running:
 2. **[CLI Guide](./cli-guide.md)** - Command-line tools reference
 3. **[Service Support](./service-support.md)** - List of all supported services
 4. **[Contributing](./contributing.md)** - Help add new services
-5. **[Examples](./examples/)** - Framework-specific examples
+5. **[Examples](./examples/nextjs.md)** - Framework-specific examples
 
 ## 🎉 Welcome to the Community!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,11 +69,11 @@ console.log(result.header);
 
 | Guide | Description |
 |-------|-------------|
-| **[Architecture](./maintainer/architecture.md)** | Technical architecture overview |
-| **[Maintainer Guide](./maintainer/maintainer-guide.md)** | Project maintenance procedures |
-| **[Release Process](./maintainer/release-process.md)** | How releases are managed |
-| **[Service Definition Guide](./maintainer/service-definition-guide.md)** | Detailed schema documentation |
-| **[NPM Publishing Guide](./maintainer/npm-publishing-guide.md)** | Package publishing procedures |
+| **[Architecture](./maintainer/ARCHITECTURE.md)** | Technical architecture overview |
+| **[Maintainer Guide](./maintainer/MAINTAINER_GUIDE.md)** | Project maintenance procedures |
+| **[Release Process](./maintainer/RELEASE_PROCESS.md)** | How releases are managed |
+| **[Service Definition Guide](./maintainer/SERVICE_DEFINITION_GUIDE.md)** | Detailed schema documentation |
+| **[NPM Publishing Guide](./maintainer/NPM_PUBLISHING_GUIDE.md)** | Package publishing procedures |
 
 ## 🎯 What is CSP Kit?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ console.log(result.header);
 |----------|-------------|
 | **[Service Support](./service-support.md)** | List of 106+ supported services |
 | **[Contributing](./contributing.md)** | How to contribute new services |
-| **[Examples](./examples/)** | Framework-specific examples |
+| **[Examples](./examples/nextjs.md)** | Framework-specific examples |
 
 ### 🔧 **For Maintainers**
 

--- a/docs/service-support.md
+++ b/docs/service-support.md
@@ -220,8 +220,8 @@ Authentication, productivity, and specialized tools.
 | Method | Best For | Time to Process |
 |--------|----------|-----------------|
 | **[GitHub Issues](https://github.com/eason-dev/csp-kit/issues/new?template=add-service.md)** | Detailed requests | 1-2 weeks |
-| **[CLI Contribution](../cli-guide.md#contributing-a-new-service)** | Developer contributors | 3-5 days |
-| **[Manual PR](../contributing.md#-adding-a-new-service)** | Advanced contributors | 1-3 days |
+| **[CLI Contribution](./cli-guide.md#contributing-a-new-service)** | Developer contributors | 3-5 days |
+| **[Manual PR](./contributing.md#-adding-a-new-service)** | Advanced contributors | 1-3 days |
 
 ### 📝 **Service Request Requirements**
 

--- a/docs/service-support.md
+++ b/docs/service-support.md
@@ -221,7 +221,7 @@ Authentication, productivity, and specialized tools.
 |--------|----------|-----------------|
 | **[GitHub Issues](https://github.com/eason-dev/csp-kit/issues/new?template=add-service.md)** | Detailed requests | 1-2 weeks |
 | **[CLI Contribution](../cli-guide.md#contributing-a-new-service)** | Developer contributors | 3-5 days |
-| **[Manual PR](../contributing.md#adding-a-new-service)** | Advanced contributors | 1-3 days |
+| **[Manual PR](../contributing.md#-adding-a-new-service)** | Advanced contributors | 1-3 days |
 
 ### 📝 **Service Request Requirements**
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -347,7 +347,7 @@ updates:
 
 ### Before Updating
 
-- [ ] Check [CHANGELOG.md](https://github.com/eason-dev/csp-kit/blob/main/CHANGELOG.md)
+- [ ] Check [GitHub Releases](https://github.com/eason-dev/csp-kit/releases) for changelog
 - [ ] Review your current CSP implementation
 - [ ] Backup your current package-lock.json
 - [ ] Ensure tests are passing


### PR DESCRIPTION
## Summary
This PR fixes all broken internal documentation links that were causing Docusaurus builds to fail in CI.

## Changes Made
- **Fixed case sensitivity issues**: Updated maintainer file references to use correct uppercase filenames (ARCHITECTURE.md, MAINTAINER_GUIDE.md, etc.)
- **Corrected section anchor links**: Fixed links to documentation sections in contributing.md and service-support.md  
- **Resolved missing file references**: Replaced broken CHANGELOG.md link with GitHub Releases and removed broken CODE_OF_CONDUCT.md link
- **Fixed example file links**: Updated broken example framework links in nextjs.md

## Test plan
- [x] Verify all internal documentation links resolve correctly
- [x] Confirm Docusaurus build passes locally
- [ ] Validate CI builds pass after merge
