### PR TITLE
Fix npm publish provenance error and clean up V2 references

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1,0 +1,133 @@
+# @csp-kit/data
+
+Service definitions and CSP mappings database for [csp-kit](https://github.com/eason-dev/csp-kit). This package provides Content Security Policy directives for 100+ popular web services and is designed to be used with `@csp-kit/generator`.
+
+## Installation
+
+**Install both packages together:**
+
+```bash
+npm install @csp-kit/generator @csp-kit/data
+# or
+yarn add @csp-kit/generator @csp-kit/data
+# or
+pnpm add @csp-kit/generator @csp-kit/data
+```
+
+## Usage
+
+This package exports service definitions that are used with `@csp-kit/generator` to create CSP headers:
+
+```javascript
+import { generateCSP } from '@csp-kit/generator';
+import { GoogleAnalytics, Stripe, GoogleFonts } from '@csp-kit/data';
+
+// Generate CSP header for your services
+const { header } = generateCSP({
+  services: [GoogleAnalytics, Stripe, GoogleFonts]
+});
+
+// Use in your application
+response.setHeader('Content-Security-Policy', header);
+```
+
+## Available Services
+
+Services are exported as named exports with PascalCase naming:
+
+```javascript
+import {
+  // Analytics
+  GoogleAnalytics,
+  MicrosoftClarity,
+  Mixpanel,
+  Amplitude,
+  Hotjar,
+  
+  // Payment
+  Stripe,
+  Paypal,
+  Square,
+  
+  // Authentication
+  Auth0,
+  Clerk,
+  FirebaseAuth,
+  
+  // Video
+  Youtube,
+  Vimeo,
+  Wistia,
+  
+  // ... and 100+ more services
+} from '@csp-kit/data';
+```
+
+## Service Categories
+
+- **analytics**: Google Analytics, Microsoft Clarity, Mixpanel, Amplitude, Heap, PostHog
+- **authentication**: Auth0, Clerk, Firebase Auth, Supabase Auth
+- **cdn**: Cloudflare, Fastly, jsDelivr, unpkg, cdnjs
+- **chat**: Intercom, Crisp, Tawk.to, Zendesk Chat
+- **fonts**: Google Fonts, Adobe Fonts
+- **forms**: Typeform, Tally, Jotform
+- **maps**: Google Maps, Mapbox
+- **marketing**: HubSpot, Mailchimp, ConvertKit
+- **monitoring**: Sentry, Datadog, LogRocket, Bugsnag
+- **payment**: Stripe, PayPal, Square
+- **social**: Twitter/X Widgets, Facebook SDK, LinkedIn
+- **video**: YouTube, Vimeo, Wistia, Loom
+- And many more...
+
+## Configurable Services
+
+Some services support dynamic configuration:
+
+```javascript
+import { GoogleMaps, Stripe } from '@csp-kit/data';
+
+// Configure services with dynamic values
+const mapsWithKey = GoogleMaps.configure({ apiKey: 'YOUR_API_KEY' });
+const stripeWithAccount = Stripe.configure({ account: 'acct_123456' });
+
+// Use with generator
+import { generateCSP } from '@csp-kit/generator';
+const { header } = generateCSP({
+  services: [mapsWithKey, stripeWithAccount]
+});
+```
+
+## TypeScript Support
+
+All services are fully typed:
+
+```typescript
+import type { CSPService } from '@csp-kit/data';
+import { GoogleAnalytics } from '@csp-kit/data';
+
+// Each service has these properties
+console.log(GoogleAnalytics.id);         // 'google-analytics'
+console.log(GoogleAnalytics.name);       // 'Google Analytics 4'
+console.log(GoogleAnalytics.category);   // 'analytics'
+console.log(GoogleAnalytics.directives); // CSP directives object
+```
+
+## Updates
+
+Service definitions are updated independently from the generator:
+
+```bash
+# Check for updates
+npm outdated @csp-kit/data
+
+# Update to latest
+npm update @csp-kit/data
+```
+
+## Contributing
+
+Want to add or update a service? See our [Contributing Guide](https://github.com/eason-dev/csp-kit/blob/main/CONTRIBUTING.md).
+
+## License
+
+MIT License - see [LICENSE](https://github.com/eason-dev/csp-kit/blob/main/LICENSE) for details.

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -1,6 +1,6 @@
 import { type CSPService, isCSPService } from '@csp-kit/data';
 import type { CSPDirectives } from '@csp-kit/data';
-import type { CSPResult, CSPOptionsV2 } from './types.js';
+import type { CSPResult, CSPOptions } from './types.js';
 import {
   generateNonce,
   mergeCSPDirectives,
@@ -19,11 +19,11 @@ function isConfiguredService(service: unknown): service is { directives: CSPDire
 }
 
 /**
- * Generate CSP header from services and options (new API)
+ * Generate CSP header from services and options
  */
-export function generateCSP(input: CSPService[] | CSPOptionsV2): CSPResult {
+export function generateCSP(input: CSPService[] | CSPOptions): CSPResult {
   // Normalize input
-  const options: CSPOptionsV2 = Array.isArray(input) ? { services: input } : input;
+  const options: CSPOptions = Array.isArray(input) ? { services: input } : input;
 
   const {
     services,
@@ -184,14 +184,14 @@ export function generateCSP(input: CSPService[] | CSPOptionsV2): CSPResult {
 /**
  * Generate CSP header string directly
  */
-export function generateCSPHeader(input: CSPService[] | CSPOptionsV2): string {
+export function generateCSPHeader(input: CSPService[] | CSPOptions): string {
   return generateCSP(input).header;
 }
 
 /**
  * Generate report-only CSP header
  */
-export function generateReportOnlyCSP(input: CSPService[] | CSPOptionsV2): CSPResult {
+export function generateReportOnlyCSP(input: CSPService[] | CSPOptions): CSPResult {
   const result = generateCSP(input);
   return {
     ...result,

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -17,7 +17,7 @@ export function generateCSPAsync(...args: Parameters<typeof generateCSPSync>): P
 export { generateNonce } from './utils.js';
 
 // Type exports
-export type { CSPOptions, CSPOptionsV2, CSPResult, NonceOptions } from './types.js';
+export type { CSPOptions, CSPResult, NonceOptions } from './types.js';
 
 // Re-export from data package for convenience
 export type {

--- a/packages/generator/src/types.ts
+++ b/packages/generator/src/types.ts
@@ -1,38 +1,9 @@
 import type { CSPDirectives, CSPService } from '@csp-kit/data';
 
 /**
- * CSP generation options (legacy API)
+ * CSP generation options
  */
 export interface CSPOptions {
-  /** List of services to include */
-  services: string[];
-
-  /** Generate a nonce for inline scripts */
-  nonce?: boolean | string;
-
-  /** Custom CSP rules to merge */
-  customRules?: CSPDirectives;
-
-  /** Generate report-only policy instead of enforcing */
-  reportOnly?: boolean;
-
-  /** Report URI for CSP violations */
-  reportUri?: string;
-
-  /** Include 'self' directive by default */
-  includeSelf?: boolean;
-
-  /** Include 'unsafe-inline' (not recommended) */
-  unsafeInline?: boolean;
-
-  /** Include 'unsafe-eval' (not recommended) */
-  unsafeEval?: boolean;
-}
-
-/**
- * CSP generation options (new API)
- */
-export interface CSPOptionsV2 {
   /** List of services to include */
   services: CSPService[];
 
@@ -55,10 +26,10 @@ export interface CSPOptionsV2 {
   unsafeEval?: boolean;
 
   /** Development-specific options */
-  development?: Partial<Omit<CSPOptionsV2, 'services' | 'development' | 'production'>>;
+  development?: Partial<Omit<CSPOptions, 'services' | 'development' | 'production'>>;
 
   /** Production-specific options */
-  production?: Partial<Omit<CSPOptionsV2, 'services' | 'development' | 'production'>>;
+  production?: Partial<Omit<CSPOptions, 'services' | 'development' | 'production'>>;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes the npm publish provenance error and cleans up all V2 type references to simplify the API.

## Changes

### 🐛 Fix npm publish provenance error
- Updated `publish.sh` script to use `--provenance=false` flag for all package publishes
- Added `provenance: false` to `publishConfig` in data package's package.json

### 🧹 Clean up V2 type references
- Renamed `CSPOptionsV2` to `CSPOptions` throughout the codebase
- Removed the legacy `CSPOptions` interface
- Updated all type imports and function signatures
- Simplified the API to have only one version

### 📝 Documentation updates
- Updated @csp-kit/generator README with correct PascalCase imports
- Created simpler @csp-kit/data README focused on usage with generator
- Fixed all code examples to use the correct import pattern

## Test plan

- [x] npm publish works without provenance errors
- [x] TypeScript compilation passes
- [x] All imports follow PascalCase convention
- [x] Documentation is consistent with actual API

🤖 Generated with [Claude Code](https://claude.ai/code)