### PR TITLE
chore: add changeset for minimal defineService API

### DIFF
--- a/.changeset/sweet-moments-relax.md
+++ b/.changeset/sweet-moments-relax.md
@@ -1,0 +1,31 @@
+---
+"@csp-kit/generator": minor
+"@csp-kit/data": minor
+---
+
+feat: minimal defineService API with variable names as identifiers
+
+Dramatically simplified the public `defineService` API to focus on essential CSP generation with only the `directives` field required. Variable names now serve as service identifiers, eliminating redundancy and cognitive overhead.
+
+**Breaking Changes:**
+- `defineService` now only requires `directives` field
+- Variable names become service identifiers (use camelCase)
+- Removed need for `id`, `name`, `category`, and other metadata fields in custom services
+
+**Migration Guide:**
+```typescript
+// Before
+const MyService = defineService({
+  id: 'my-service',
+  name: 'My Service',
+  category: ServiceCategory.API,
+  directives: { 'script-src': ['https://api.example.com'] }
+});
+
+// After
+const myService = defineService({
+  directives: { 'script-src': ['https://api.example.com'] }
+});
+```
+
+This change makes the library significantly easier to use while maintaining full TypeScript support and compatibility with the existing generator.


### PR DESCRIPTION
## Summary

This PR adds a changeset for the minimal defineService API feature that was merged in PR #79. This will trigger a release of the `@csp-kit/generator` and `@csp-kit/data` packages with the new simplified API.

## Changes from PR #79

The previous PR introduced a dramatically simplified `defineService` API:
- Only requires `directives` field
- Variable names serve as service identifiers
- Eliminated redundancy and cognitive overhead

## Release Details

- **Version Bump**: Minor (new feature)
- **Packages**: `@csp-kit/generator` and `@csp-kit/data`

Once this PR is merged, the changeset action will create a "Version Packages" PR to handle the actual release.