### PR TITLE
fix: comprehensive npm authentication fix for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,21 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      # Configure npm authentication
+      - name: Configure npm auth
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
+          echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
+          echo "always-auth=true" >> ~/.npmrc
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Verify npm auth (optional, for debugging)
+      - name: Verify npm authentication
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       # Create Release Pull Request or Publish to npm
       - name: Create Release Pull Request or Publish
         id: changesets

--- a/.npmrc
+++ b/.npmrc
@@ -14,3 +14,7 @@ audit-level=moderate
 # Development settings
 engine-strict=true
 auto-install-peers=true
+
+# CI Authentication (only used in CI environment)
+# The auth token is set via NODE_AUTH_TOKEN environment variable
+# //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -1,0 +1,101 @@
+# Release Setup Guide
+
+This guide explains how to set up automated releases for CSP Kit packages.
+
+## Prerequisites
+
+1. **NPM Account**: You need an npm account with publish permissions for the `@csp-kit` scope
+2. **GitHub Repository Access**: Admin access to the repository for setting secrets
+
+## Step 1: Create NPM Token
+
+1. Log in to [npmjs.com](https://www.npmjs.com)
+2. Click on your profile picture → "Access Tokens"
+3. Click "Generate New Token"
+4. Select "Classic Token" (Automation type)
+5. Name it something like "csp-kit-github-actions"
+6. Copy the token (it starts with `npm_`)
+
+## Step 2: Add NPM Token to GitHub Secrets
+
+1. Go to your repository on GitHub
+2. Navigate to Settings → Secrets and variables → Actions
+3. Click "New repository secret"
+4. Name: `NPM_TOKEN`
+5. Value: Paste your npm token
+6. Click "Add secret"
+
+## Step 3: (Optional) Add GitHub PAT for Changesets
+
+For changesets to create pull requests, you need a Personal Access Token:
+
+1. Go to GitHub Settings → Developer settings → Personal access tokens
+2. Generate a new token (classic) with these permissions:
+   - `repo` (full control)
+   - `workflow` (update workflows)
+3. Add it as a secret named `CHANGESET_GITHUB_TOKEN`
+
+## Release Process
+
+### Automated Release (Recommended)
+
+1. Create changesets for your changes:
+   ```bash
+   pnpm changeset
+   ```
+
+2. Commit and push to main
+3. The workflow will automatically:
+   - Create a "Version Packages" PR
+   - When merged, publish to npm
+   - Create GitHub releases
+
+### Manual Release (Fallback)
+
+If the automated release fails:
+
+```bash
+# Set your npm token
+export NPM_TOKEN=npm_xxxxxxxxxxxx
+
+# Run the manual publish script
+./scripts/manual-publish.sh
+```
+
+## Troubleshooting
+
+### Error: 404 Not Found when publishing
+
+**Cause**: NPM token is invalid or doesn't have publish permissions
+
+**Solution**:
+1. Verify your npm token has publish permissions
+2. Check if you're logged in: `npm whoami`
+3. Ensure the token is set correctly in GitHub secrets
+
+### Error: 403 Forbidden
+
+**Cause**: You don't have permission to publish to the @csp-kit scope
+
+**Solution**:
+1. Ensure your npm account has access to the @csp-kit organization
+2. Check package access: `npm access ls-packages @csp-kit`
+
+### Error: Packages not publishing
+
+**Cause**: Version already exists on npm
+
+**Solution**:
+1. Check current npm versions: `npm view @csp-kit/generator version`
+2. Ensure local versions are bumped: `pnpm changeset version`
+3. Commit version changes before publishing
+
+## Verifying Setup
+
+Run this command to verify your npm token works:
+
+```bash
+NPM_TOKEN=your-token-here npm whoami
+```
+
+You should see your npm username.

--- a/scripts/manual-publish.sh
+++ b/scripts/manual-publish.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Manual publish script for CSP Kit packages
+# This script can be used as a fallback if the automated release fails
+
+set -e
+
+echo "=== CSP Kit Manual Publish Script ==="
+echo ""
+
+# Check if NPM_TOKEN is set
+if [ -z "$NPM_TOKEN" ]; then
+  echo "Error: NPM_TOKEN environment variable is not set"
+  echo "Usage: NPM_TOKEN=your-token ./scripts/manual-publish.sh"
+  exit 1
+fi
+
+# Configure npm authentication
+echo "Configuring npm authentication..."
+npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+npm config set registry https://registry.npmjs.org/
+
+# Verify authentication
+echo "Verifying npm authentication..."
+npm whoami || {
+  echo "Error: npm authentication failed"
+  exit 1
+}
+
+# Build packages
+echo "Building packages..."
+pnpm build
+
+# Get current versions
+echo ""
+echo "Current package versions:"
+echo "- @csp-kit/cli: $(grep '"version"' packages/cli/package.json | cut -d'"' -f4)"
+echo "- @csp-kit/data: $(grep '"version"' packages/data/package.json | cut -d'"' -f4)"
+echo "- @csp-kit/generator: $(grep '"version"' packages/generator/package.json | cut -d'"' -f4)"
+
+# Ask for confirmation
+echo ""
+read -p "Do you want to publish these packages? (y/N) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  echo "Publish cancelled"
+  exit 0
+fi
+
+# Publish packages in correct order (data first, then generator, then cli)
+echo ""
+echo "Publishing @csp-kit/data..."
+cd packages/data
+npm publish --access public || echo "Warning: @csp-kit/data publish failed (might already be published)"
+cd ../..
+
+echo ""
+echo "Publishing @csp-kit/generator..."
+cd packages/generator
+# Replace workspace protocol with actual version
+DATA_VERSION=$(grep '"version"' ../data/package.json | cut -d'"' -f4)
+sed -i.bak "s/\"@csp-kit\/data\": \"workspace:\*\"/\"@csp-kit\/data\": \"^$DATA_VERSION\"/" package.json
+npm publish --access public || echo "Warning: @csp-kit/generator publish failed (might already be published)"
+# Restore original package.json
+mv package.json.bak package.json
+cd ../..
+
+echo ""
+echo "Publishing @csp-kit/cli..."
+cd packages/cli
+# Replace workspace protocol with actual version
+DATA_VERSION=$(grep '"version"' ../data/package.json | cut -d'"' -f4)
+sed -i.bak "s/\"@csp-kit\/data\": \"workspace:\*\"/\"@csp-kit\/data\": \"^$DATA_VERSION\"/" package.json
+npm publish --access public || echo "Warning: @csp-kit/cli publish failed (might already be published)"
+# Restore original package.json
+mv package.json.bak package.json
+cd ../..
+
+echo ""
+echo "=== Publish Complete ==="
+echo "Don't forget to:"
+echo "1. Create git tags for the published versions"
+echo "2. Create GitHub releases"
+echo "3. Update the changelog"

--- a/scripts/verify-npm-auth.sh
+++ b/scripts/verify-npm-auth.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Script to verify npm authentication setup
+
+echo "=== NPM Authentication Verification ==="
+echo ""
+
+# Check if NPM_TOKEN is provided
+if [ -z "$1" ]; then
+  echo "Usage: ./scripts/verify-npm-auth.sh <npm-token>"
+  echo "Example: ./scripts/verify-npm-auth.sh npm_xxxxxxxxxxxx"
+  exit 1
+fi
+
+NPM_TOKEN=$1
+
+# Test authentication
+echo "Testing npm authentication..."
+NPM_TOKEN=$NPM_TOKEN npm whoami 2>&1 || {
+  echo ""
+  echo "❌ Authentication failed!"
+  echo "Please check:"
+  echo "1. Your token is valid"
+  echo "2. Your token has not expired"
+  echo "3. Your token has automation permissions"
+  exit 1
+}
+
+echo ""
+echo "✅ Authentication successful!"
+echo ""
+
+# Check package access
+echo "Checking package access..."
+NPM_TOKEN=$NPM_TOKEN npm access ls-packages 2>&1 | grep "@csp-kit" || {
+  echo "⚠️  No @csp-kit packages found in your npm account"
+  echo "This might be normal if you haven't published any packages yet"
+}
+
+echo ""
+echo "=== Setup Instructions ==="
+echo "1. Copy your NPM token"
+echo "2. Go to GitHub repository settings"
+echo "3. Navigate to Secrets and variables → Actions"
+echo "4. Add a new secret named 'NPM_TOKEN' with your token value"
+echo ""
+echo "Your token is valid and ready to use! ✅"


### PR DESCRIPTION
## Summary

This PR provides a comprehensive fix for the npm authentication issues that are preventing automated releases. The root cause was identified as missing or invalid NPM authentication tokens during the publish process.

## Root Cause

The workflow was failing with `404 Not Found` errors when trying to publish packages because:
- The `NODE_AUTH_TOKEN` was not being properly configured for npm authentication
- The npm registry authentication wasn't explicitly set in the workflow

## Changes

### 1. Enhanced GitHub Actions Workflow
- ✅ Added explicit npm authentication configuration step
- ✅ Added npm authentication verification step (npm whoami)
- ✅ Ensures ~/.npmrc is properly configured with auth token

### 2. Manual Publish Script (`scripts/manual-publish.sh`)
- 🔧 Fallback option for manual publishing if automation fails
- 🔧 Handles workspace protocol replacement for dependencies
- 🔧 Publishes packages in correct dependency order

### 3. NPM Auth Verification Script (`scripts/verify-npm-auth.sh`)
- 🔍 Helps users verify their NPM token is valid
- 🔍 Tests authentication before attempting publish
- 🔍 Provides clear setup instructions

### 4. Comprehensive Documentation (`docs/RELEASE_SETUP.md`)
- 📚 Step-by-step guide for setting up NPM authentication
- 📚 Troubleshooting common issues
- 📚 Instructions for both automated and manual releases

## Setup Required

**IMPORTANT**: You need to ensure the `NPM_TOKEN` secret is properly configured:

1. Generate an npm automation token at npmjs.com
2. Add it to GitHub Secrets as `NPM_TOKEN`
3. Verify it works: `NPM_TOKEN=your-token ./scripts/verify-npm-auth.sh your-token`

## Testing

The fix has been designed to:
- ✅ Explicitly configure npm authentication before publishing
- ✅ Verify authentication works before attempting publish
- ✅ Provide clear error messages if authentication fails
- ✅ Offer manual fallback option if automation fails

## Next Steps

After merging this PR:
1. Ensure `NPM_TOKEN` is set in repository secrets
2. The next workflow run should successfully publish the pending versions:
   - @csp-kit/cli@0.2.3
   - @csp-kit/data@0.3.0
   - @csp-kit/generator@0.3.0

Fixes the issue from: https://github.com/eason-dev/csp-kit/actions/runs/16392101255/job/46319418697