### PR TITLE
build(deps): fix on-headers CVE-2025-7339 vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
       "esbuild": ">=0.25.0",
       "brace-expansion": ">=2.0.2",
       "webpack-dev-server": ">=5.2.1",
-      "prismjs": ">=1.30.0"
+      "prismjs": ">=1.30.0",
+      "on-headers": ">=1.1.0"
     }
   },
   "packageManager": "pnpm@10.12.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   brace-expansion: '>=2.0.2'
   webpack-dev-server: '>=5.2.1'
   prismjs: '>=1.30.0'
+  on-headers: '>=1.1.0'
 
 importers:
 
@@ -6417,8 +6418,8 @@ packages:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
 
-  on-headers@1.0.2:
-    resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
@@ -13401,7 +13402,7 @@ snapshots:
       compressible: 2.0.18
       debug: 2.6.9
       negotiator: 0.6.4
-      on-headers: 1.0.2
+      on-headers: 1.1.0
       safe-buffer: 5.2.1
       vary: 1.1.2
     transitivePeerDependencies:
@@ -16378,7 +16379,7 @@ snapshots:
     dependencies:
       ee-first: 1.1.1
 
-  on-headers@1.0.2: {}
+  on-headers@1.1.0: {}
 
   once@1.4.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Fixes CVE-2025-7339 vulnerability in on-headers package
- Updates on-headers from 1.0.2 to 1.1.0 through pnpm override
- This is a low severity vulnerability affecting HTTP response header manipulation

## Details
The vulnerability was in the `on-headers` package (version < 1.1.0) which is used by the `compression` middleware, which in turn is used by `webpack-dev-server` in Docusaurus.

## Security Advisory
- GHSA ID: GHSA-76c9-3jph-rj3q
- CVE ID: CVE-2025-7339
- Severity: Low
- CVSS Score: 3.4

## Test Plan
- [x] Updated pnpm override to force on-headers >= 1.1.0
- [x] Ran `pnpm install` to update lockfile
- [x] Verified vulnerability is fixed with `pnpm audit` (no vulnerabilities found)
- [x] Confirmed on-headers is now at version 1.1.0 in lockfile