### PR TITLE
feat(generator): simplify CSP API with direct boolean flags

### DIFF
--- a/.changeset/simplify-csp-api.md
+++ b/.changeset/simplify-csp-api.md
@@ -1,0 +1,31 @@
+---
+"@csp-kit/generator": minor
+"web": minor
+---
+
+Simplify CSP API with direct boolean flags
+
+Replace abstract security levels with intuitive boolean flags for better control over CSP generation:
+
+- Add `includeSelf`, `includeUnsafeInline`, and `includeUnsafeEval` boolean options
+- Change default behavior: `includeSelf` now defaults to `false` for more secure CSP generation
+- Add UI toggles in web app Advanced Configuration section
+- Remove `securityLevel` option (breaking change)
+
+**Breaking Changes:**
+- Removed `securityLevel` option, replaced with direct boolean flags
+- `includeSelf` now defaults to `false` instead of `true`
+
+**Migration:**
+```typescript
+// Before
+generateCSP({ services: [GoogleAnalytics], securityLevel: 'strict' });
+
+// After  
+generateCSP({ 
+  services: [GoogleAnalytics], 
+  includeSelf: false,
+  includeUnsafeInline: false,
+  includeUnsafeEval: false 
+});
+```

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -9,11 +9,13 @@ This directory contains Claude Code configuration and hooks for the CSP Kit proj
 The `format-files.sh` script automatically formats files after Claude makes changes using the Write, Edit, or MultiEdit tools.
 
 **Supported file types:**
+
 - TypeScript/JavaScript (`.ts`, `.tsx`, `.js`, `.jsx`) - formatted with Prettier
-- Markdown (`.md`) - formatted with Prettier  
+- Markdown (`.md`) - formatted with Prettier
 - JSON (`.json`) - formatted with Prettier
 
 **How it works:**
+
 1. Claude makes changes to a file using Write, Edit, or MultiEdit
 2. The PostToolUse hook is triggered
 3. The script receives file information via JSON input
@@ -21,6 +23,7 @@ The `format-files.sh` script automatically formats files after Claude makes chan
 5. The file is automatically formatted in place
 
 **Requirements:**
+
 - `jq` for JSON parsing (optional, falls back to grep)
 - `pnpm` and `prettier` for formatting (tries pnpm first, then global prettier)
 
@@ -34,6 +37,7 @@ This configuration is automatically active when Claude Code is run from this pro
 ## Debugging
 
 If formatting fails, check:
+
 1. File permissions on `format-files.sh` (should be executable)
 2. `pnpm` and `prettier` are available in the project
 3. Check Claude Code output for hook execution logs

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,39 @@
+# Claude Code Configuration
+
+This directory contains Claude Code configuration and hooks for the CSP Kit project.
+
+## Hooks
+
+### Auto-formatting Hook
+
+The `format-files.sh` script automatically formats files after Claude makes changes using the Write, Edit, or MultiEdit tools.
+
+**Supported file types:**
+- TypeScript/JavaScript (`.ts`, `.tsx`, `.js`, `.jsx`) - formatted with Prettier
+- Markdown (`.md`) - formatted with Prettier  
+- JSON (`.json`) - formatted with Prettier
+
+**How it works:**
+1. Claude makes changes to a file using Write, Edit, or MultiEdit
+2. The PostToolUse hook is triggered
+3. The script receives file information via JSON input
+4. Based on the file extension, the appropriate formatter is run
+5. The file is automatically formatted in place
+
+**Requirements:**
+- `jq` for JSON parsing (optional, falls back to grep)
+- `pnpm` and `prettier` for formatting (tries pnpm first, then global prettier)
+
+**Configuration:**
+The hook is configured in `settings.json` to match Write, Edit, and MultiEdit tools.
+
+## Usage
+
+This configuration is automatically active when Claude Code is run from this project directory. No manual setup is required - the hooks will automatically format files when Claude makes changes.
+
+## Debugging
+
+If formatting fails, check:
+1. File permissions on `format-files.sh` (should be executable)
+2. `pnpm` and `prettier` are available in the project
+3. Check Claude Code output for hook execution logs

--- a/.claude/format-files.sh
+++ b/.claude/format-files.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Claude Code hook script for automatic file formatting
+# This script is triggered after Claude writes, edits, or multi-edits files
+
+set -e
+
+# Change to the project root directory
+cd "$(dirname "$0")/.."
+
+# Read JSON input from stdin
+input=$(cat)
+
+# Extract file path from the JSON input
+# Try different possible field names that Claude might use
+file_path=$(echo "$input" | jq -r '.file_path // .filepath // .path // empty')
+
+# If jq is not available, try a simple grep approach
+if [ -z "$file_path" ] && command -v grep >/dev/null 2>&1; then
+    file_path=$(echo "$input" | grep -o '"file_path"\s*:\s*"[^"]*"' | cut -d'"' -f4 2>/dev/null || echo "")
+fi
+
+if [ -z "$file_path" ]; then
+    echo "No file path found in input, skipping formatting"
+    exit 0
+fi
+
+# Check if file exists
+if [ ! -f "$file_path" ]; then
+    echo "File $file_path does not exist, skipping formatting"
+    exit 0
+fi
+
+# Get file extension
+extension="${file_path##*.}"
+
+echo "Formatting file: $file_path (extension: $extension)"
+
+case "$extension" in
+    ts|tsx|js|jsx)
+        echo "Running Prettier on TypeScript/JavaScript file..."
+        if command -v pnpm >/dev/null 2>&1; then
+            echo "Using pnpm exec prettier..."
+            pnpm exec prettier --write "$file_path" || {
+                echo "Prettier via pnpm failed, trying global prettier..."
+                prettier --write "$file_path" 2>/dev/null || echo "Prettier formatting failed"
+            }
+        elif command -v prettier >/dev/null 2>&1; then
+            echo "Using global prettier..."
+            prettier --write "$file_path" || echo "Prettier formatting failed"
+        else
+            echo "Prettier not available, skipping formatting"
+        fi
+        ;;
+    md)
+        echo "Running Prettier on Markdown file..."
+        if command -v pnpm >/dev/null 2>&1; then
+            echo "Using pnpm exec prettier..."
+            pnpm exec prettier --write "$file_path" || {
+                echo "Prettier via pnpm failed, trying global prettier..."
+                prettier --write "$file_path" 2>/dev/null || echo "Prettier formatting failed"
+            }
+        elif command -v prettier >/dev/null 2>&1; then
+            echo "Using global prettier..."
+            prettier --write "$file_path" || echo "Prettier formatting failed"
+        else
+            echo "Prettier not available, skipping formatting"
+        fi
+        ;;
+    json)
+        echo "Running Prettier on JSON file..."
+        if command -v pnpm >/dev/null 2>&1; then
+            echo "Using pnpm exec prettier..."
+            pnpm exec prettier --write "$file_path" || {
+                echo "Prettier via pnpm failed, trying global prettier..."
+                prettier --write "$file_path" 2>/dev/null || echo "Prettier formatting failed"
+            }
+        elif command -v prettier >/dev/null 2>&1; then
+            echo "Using global prettier..."
+            prettier --write "$file_path" || echo "Prettier formatting failed"
+        else
+            echo "Prettier not available, skipping formatting"
+        fi
+        ;;
+    *)
+        echo "No formatting rule for extension: $extension"
+        ;;
+esac
+
+echo "Formatting completed for: $file_path"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/format-files.sh",
+            "description": "Auto-format files after Claude makes changes"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -255,9 +255,9 @@ type CSPOptions = {
   nonce?: boolean | string; // Generate or use nonce
   additionalRules?: CSPDirectives; // Additional CSP rules
   reportUri?: string; // Violation reporting endpoint
-  includeSelf?: boolean; // Include 'self' (default: true)
-  unsafeInline?: boolean; // Allow unsafe-inline (not recommended)
-  unsafeEval?: boolean; // Allow unsafe-eval (not recommended)
+  includeSelf?: boolean; // Include 'self' (default: false)
+  includeUnsafeInline?: boolean; // Allow unsafe-inline (not recommended)
+  includeUnsafeEval?: boolean; // Allow unsafe-eval (not recommended)
   development?: Partial<CSPOptions>; // Dev-only options
   production?: Partial<CSPOptions>; // Production-only options
 };

--- a/apps/web/__tests__/middleware.test.ts
+++ b/apps/web/__tests__/middleware.test.ts
@@ -104,7 +104,7 @@ describe('Middleware', () => {
     expect(mockGenerateCSP).toHaveBeenCalledWith(
       expect.objectContaining({
         development: {
-          unsafeEval: true,
+          includeUnsafeEval: true,
         },
       })
     );

--- a/apps/web/app/api/generate-csp/route.ts
+++ b/apps/web/app/api/generate-csp/route.ts
@@ -6,7 +6,15 @@ import type { CSPService } from '@csp-kit/data';
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { services: serviceIds, nonce, customRules, reportUri } = body;
+    const {
+      services: serviceIds,
+      nonce,
+      customRules,
+      reportUri,
+      includeSelf,
+      includeUnsafeInline,
+      includeUnsafeEval,
+    } = body;
 
     // Convert service IDs to CSPService objects
     const services: CSPService[] = [];
@@ -34,6 +42,9 @@ export async function POST(request: NextRequest) {
       nonce,
       additionalRules: customRules,
       reportUri,
+      includeSelf,
+      includeUnsafeInline,
+      includeUnsafeEval,
     });
 
     return NextResponse.json(result);

--- a/apps/web/components/csp/usage-methods.tsx
+++ b/apps/web/components/csp/usage-methods.tsx
@@ -20,6 +20,9 @@ interface UsageMethodsProps {
   useNonce?: boolean;
   reportUri?: string;
   customRules?: Record<string, string[]>;
+  includeSelf?: boolean;
+  includeUnsafeInline?: boolean;
+  includeUnsafeEval?: boolean;
 }
 
 // Usage method options
@@ -63,6 +66,9 @@ export function UsageMethods({
   useNonce = false,
   reportUri = '',
   customRules = {},
+  includeSelf = false,
+  includeUnsafeInline = false,
+  includeUnsafeEval = false,
 }: UsageMethodsProps) {
   const [selectedUsageMethod, setSelectedUsageMethod] = useState('npm-package');
   const [copied, setCopied] = useState(false);
@@ -99,7 +105,7 @@ import { ${serviceImports || 'GoogleAnalytics, Stripe'} } from '@csp-kit/data';
 
 const result = generateCSP({
   services: [${serviceImports || 'GoogleAnalytics, Stripe'}],
-  nonce: ${useNonce},${
+  nonce: ${useNonce},${includeSelf ? '\n  includeSelf: true,' : ''}${includeUnsafeInline ? '\n  includeUnsafeInline: true,' : ''}${includeUnsafeEval ? '\n  includeUnsafeEval: true,' : ''}${
     Object.keys(customRules).length > 0
       ? '\n  additionalRules: {\n' +
         Object.entries(customRules)

--- a/apps/web/components/pages/progressive-homepage.tsx
+++ b/apps/web/components/pages/progressive-homepage.tsx
@@ -129,7 +129,7 @@ export default function ProgressiveHomepage({ serviceRegistry }: ProgressiveHome
       setResult(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedServices, useNonce, reportUri, customRules]);
+  }, [selectedServices, useNonce, reportUri, customRules, includeSelf, includeUnsafeInline, includeUnsafeEval]);
 
   const generateCurrentCSP = async () => {
     try {
@@ -641,6 +641,9 @@ export default function ProgressiveHomepage({ serviceRegistry }: ProgressiveHome
                       serviceIds={selectedServices.map(s => s.id)}
                       useNonce={useNonce}
                       reportUri={reportUri}
+                      includeSelf={includeSelf}
+                      includeUnsafeInline={includeUnsafeInline}
+                      includeUnsafeEval={includeUnsafeEval}
                       customRules={Object.fromEntries(
                         Object.entries(customRules)
                           .filter(

--- a/apps/web/components/pages/progressive-homepage.tsx
+++ b/apps/web/components/pages/progressive-homepage.tsx
@@ -84,6 +84,9 @@ export default function ProgressiveHomepage({ serviceRegistry }: ProgressiveHome
   // State management
   const [useNonce, setUseNonce] = useState(false);
   const [reportUri, setReportUri] = useState('');
+  const [includeSelf, setIncludeSelf] = useState(false);
+  const [includeUnsafeInline, setIncludeUnsafeInline] = useState(false);
+  const [includeUnsafeEval, setIncludeUnsafeEval] = useState(false);
   const [customRules, setCustomRules] = useState<Record<string, string>>({
     'script-src': '',
     'style-src': '',
@@ -154,6 +157,9 @@ export default function ProgressiveHomepage({ serviceRegistry }: ProgressiveHome
           nonce: useNonce,
           customRules: customRulesObj,
           reportUri: reportUri || undefined,
+          includeSelf,
+          includeUnsafeInline,
+          includeUnsafeEval,
         }),
       });
 
@@ -348,6 +354,21 @@ export default function ProgressiveHomepage({ serviceRegistry }: ProgressiveHome
                               Report URI
                             </Badge>
                           )}
+                          {includeSelf && (
+                            <Badge variant="secondary" className="text-xs" data-badge>
+                              &apos;self&apos;
+                            </Badge>
+                          )}
+                          {includeUnsafeInline && (
+                            <Badge variant="destructive" className="text-xs" data-badge>
+                              ⚠️ unsafe-inline
+                            </Badge>
+                          )}
+                          {includeUnsafeEval && (
+                            <Badge variant="destructive" className="text-xs" data-badge>
+                              ⚠️ unsafe-eval
+                            </Badge>
+                          )}
                         </div>
                       </div>
                     </AccordionTrigger>
@@ -389,6 +410,69 @@ export default function ProgressiveHomepage({ serviceRegistry }: ProgressiveHome
                           <p className="text-muted-foreground text-xs">
                             CSP violations will be reported to this endpoint
                           </p>
+                        </div>
+
+                        <div className="flex items-center justify-between">
+                          <div className="space-y-0.5">
+                            <div className="flex items-center gap-2">
+                              <Label>Include &apos;self&apos;</Label>
+                              <InfoTooltip
+                                content="Includes 'self' in CSP directives, allowing resources from the same origin. This is common but not always necessary."
+                                referenceUrl="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#self"
+                                referenceText="MDN: 'self' source"
+                              />
+                            </div>
+                            <p className="text-muted-foreground text-xs">
+                              Allow resources from the same origin
+                            </p>
+                          </div>
+                          <Switch checked={includeSelf} onCheckedChange={setIncludeSelf} />
+                        </div>
+
+                        <div className="flex items-center justify-between">
+                          <div className="space-y-0.5">
+                            <div className="flex items-center gap-2">
+                              <Label>Include &apos;unsafe-inline&apos;</Label>
+                              <InfoTooltip
+                                content="WARNING: Allows inline scripts and styles. This significantly reduces security by enabling XSS attacks. Only use when absolutely necessary."
+                                referenceUrl="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe-inline"
+                                referenceText="MDN: 'unsafe-inline'"
+                              />
+                            </div>
+                            <p className="text-muted-foreground text-xs">
+                              <span className="text-orange-600 dark:text-orange-400">
+                                ⚠️ Not recommended
+                              </span>{' '}
+                              - Allows inline scripts/styles
+                            </p>
+                          </div>
+                          <Switch
+                            checked={includeUnsafeInline}
+                            onCheckedChange={setIncludeUnsafeInline}
+                          />
+                        </div>
+
+                        <div className="flex items-center justify-between">
+                          <div className="space-y-0.5">
+                            <div className="flex items-center gap-2">
+                              <Label>Include &apos;unsafe-eval&apos;</Label>
+                              <InfoTooltip
+                                content="WARNING: Allows eval() and similar JavaScript functions. This reduces security and should be avoided unless required for legacy code."
+                                referenceUrl="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe-eval"
+                                referenceText="MDN: 'unsafe-eval'"
+                              />
+                            </div>
+                            <p className="text-muted-foreground text-xs">
+                              <span className="text-orange-600 dark:text-orange-400">
+                                ⚠️ Not recommended
+                              </span>{' '}
+                              - Allows eval() and similar functions
+                            </p>
+                          </div>
+                          <Switch
+                            checked={includeUnsafeEval}
+                            onCheckedChange={setIncludeUnsafeEval}
+                          />
                         </div>
                       </div>
                     </AccordionContent>

--- a/apps/web/components/pages/progressive-homepage.tsx
+++ b/apps/web/components/pages/progressive-homepage.tsx
@@ -129,7 +129,15 @@ export default function ProgressiveHomepage({ serviceRegistry }: ProgressiveHome
       setResult(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedServices, useNonce, reportUri, customRules, includeSelf, includeUnsafeInline, includeUnsafeEval]);
+  }, [
+    selectedServices,
+    useNonce,
+    reportUri,
+    customRules,
+    includeSelf,
+    includeUnsafeInline,
+    includeUnsafeEval,
+  ]);
 
   const generateCurrentCSP = async () => {
     try {

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -11,7 +11,7 @@ export function middleware(request: NextRequest) {
     nonce,
     development: {
       // In development, we might need unsafe-eval for hot reloading
-      unsafeEval: process.env.NODE_ENV !== 'production',
+      includeUnsafeEval: process.env.NODE_ENV !== 'production',
     },
     // Include 'self' directive for Next.js assets
     includeSelf: true,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -37,9 +37,9 @@ interface CSPOptions {
   nonce?: boolean | string; // Generate nonce or use provided value
   additionalRules?: CSPDirectives; // Additional CSP rules
   reportUri?: string; // CSP violation reporting endpoint
-  includeSelf?: boolean; // Include 'self' directive (default: true)
-  unsafeInline?: boolean; // Allow unsafe-inline (not recommended)
-  unsafeEval?: boolean; // Allow unsafe-eval (not recommended)
+  includeSelf?: boolean; // Include 'self' directive (default: false)
+  includeUnsafeInline?: boolean; // Allow unsafe-inline (not recommended)
+  includeUnsafeEval?: boolean; // Allow unsafe-eval (not recommended)
   development?: Partial<CSPOptions>; // Dev-only options
   production?: Partial<CSPOptions>; // Production-only options
 }
@@ -86,7 +86,7 @@ const result = generateCSP({
 const result = generateCSP({
   services: [GoogleAnalytics],
   development: {
-    unsafeEval: true, // For hot reload
+    includeUnsafeEval: true, // For hot reload
     additionalRules: {
       'connect-src': ['ws://localhost:*'],
     },
@@ -451,7 +451,7 @@ CSP Kit provides helpful error messages and warnings:
 ```typescript
 const result = generateCSP({
   services: [GoogleAnalytics],
-  unsafeInline: true, // Not recommended
+  includeUnsafeInline: true, // Not recommended
 });
 
 // Check warnings

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,13 +49,11 @@ pnpm add @csp-kit/generator @csp-kit/data
 import { generateCSP } from '@csp-kit/generator';
 import { GoogleAnalytics, Stripe, GoogleFonts } from '@csp-kit/data';
 
-// Generate CSP using imported services
-const result = generateCSP({
-  services: [GoogleAnalytics, Stripe, GoogleFonts],
-});
+// Generate CSP using imported services (simple array syntax)
+const result = generateCSP([GoogleAnalytics, Stripe, GoogleFonts]);
 
 console.log(result.header);
-// Output: "script-src 'self' https://www.googletagmanager.com https://js.stripe.com; style-src 'self' https://fonts.googleapis.com; ..."
+// Output: "script-src https://www.googletagmanager.com https://js.stripe.com; style-src https://fonts.googleapis.com; ..."
 
 // Use the CSP header
 response.setHeader('Content-Security-Policy', result.header);
@@ -85,9 +83,7 @@ import { generateCSPHeader } from '@csp-kit/generator';
 import { GoogleAnalytics, VercelAnalytics, GoogleFonts } from '@csp-kit/data';
 
 export function middleware(request: NextRequest) {
-  const csp = generateCSPHeader({
-    services: [GoogleAnalytics, VercelAnalytics, GoogleFonts],
-  });
+  const csp = generateCSPHeader([GoogleAnalytics, VercelAnalytics, GoogleFonts]);
 
   const response = NextResponse.next();
   response.headers.set('Content-Security-Policy', csp);
@@ -129,9 +125,7 @@ import { defineConfig } from 'vite';
 import { generateCSPHeader } from '@csp-kit/generator';
 import { GoogleAnalytics, GoogleFonts } from '@csp-kit/data';
 
-const csp = generateCSPHeader({
-  services: [GoogleAnalytics, GoogleFonts],
-});
+const csp = generateCSPHeader([GoogleAnalytics, GoogleFonts]);
 
 export default defineConfig({
   server: {
@@ -151,9 +145,7 @@ Generate CSP headers and add them to your hosting configuration:
 import { generateCSPHeader } from '@csp-kit/generator';
 import { GoogleAnalytics, GoogleFonts } from '@csp-kit/data';
 
-const csp = generateCSPHeader({
-  services: [GoogleAnalytics, GoogleFonts],
-});
+const csp = generateCSPHeader([GoogleAnalytics, GoogleFonts]);
 
 console.log(csp);
 // Copy this output to your configuration files
@@ -207,6 +199,7 @@ const result = generateCSP({
   services: [GoogleAnalytics, Stripe, MyAPI],
   nonce: true, // Generate nonce for inline scripts
   reportUri: 'https://my-site.com/csp-report',
+  includeSelf: true, // Include 'self' in common directives
 });
 ```
 
@@ -239,10 +232,12 @@ Test CSP without breaking your site:
 import { generateReportOnlyCSP } from '@csp-kit/generator';
 import { GoogleAnalytics, Stripe } from '@csp-kit/data';
 
-const reportOnlyHeader = generateReportOnlyCSP({
+const result = generateReportOnlyCSP({
   services: [GoogleAnalytics, Stripe],
   reportUri: '/api/csp-violations',
 });
+
+const reportOnlyHeader = result.header;
 
 // Use report-only header for testing
 response.setHeader('Content-Security-Policy-Report-Only', reportOnlyHeader);
@@ -267,7 +262,7 @@ const isDevelopment = process.env.NODE_ENV === 'development';
 const result = generateCSP({
   services: [GoogleAnalytics, Stripe, ...(isDevelopment ? [DevTools] : [])],
   development: {
-    unsafeEval: true, // Allow eval in development
+    includeUnsafeEval: true, // Allow eval in development
     additionalRules: {
       'connect-src': ['ws://localhost:*'],
     },

--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -33,9 +33,9 @@ import { generateCSP } from '@csp-kit/generator';
 import { GoogleAnalytics } from '@csp-kit/data';
 
 // Generate CSP using service objects
-const result = generateCSP({ services: [GoogleAnalytics] });
+const result = generateCSP([GoogleAnalytics]);
 console.log(result.header);
-// Output: script-src 'self' https://www.google-analytics.com https://www.googletagmanager.com; img-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net
+// Output: script-src https://www.google-analytics.com https://www.googletagmanager.com; img-src https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com; connect-src https://www.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net
 
 // Use the CSP header in your response
 response.setHeader('Content-Security-Policy', result.header);
@@ -49,14 +49,17 @@ response.setHeader('Content-Security-Policy', result.header);
 import { generateCSP } from '@csp-kit/generator';
 import { GoogleAnalytics, MicrosoftClarity, Typeform } from '@csp-kit/data';
 
-// Single service
-const result = generateCSP({ services: [GoogleAnalytics] });
+// Single service (simple array syntax)
+const result = generateCSP([GoogleAnalytics]);
 
-// Multiple services
-const result = generateCSP({ services: [GoogleAnalytics, MicrosoftClarity, Typeform] });
-
-// Shorthand syntax (array only)
+// Multiple services (simple array syntax)
 const result = generateCSP([GoogleAnalytics, MicrosoftClarity, Typeform]);
+
+// With options object (for advanced configuration)
+const result = generateCSP({
+  services: [GoogleAnalytics, MicrosoftClarity, Typeform],
+  includeSelf: true,
+});
 ```
 
 ### Advanced Usage
@@ -74,9 +77,9 @@ const result = generateCSP({
     'img-src': ['data:', 'blob:'],
   },
   reportUri: 'https://my-site.com/csp-report',
-  includeSelf: true, // Include 'self' in all directives (default: true)
-  unsafeInline: false, // Allow 'unsafe-inline' (default: false)
-  unsafeEval: false, // Allow 'unsafe-eval' (default: false)
+  includeSelf: true, // Include 'self' in common directives (default: false)
+  includeUnsafeInline: false, // Allow 'unsafe-inline' (default: false, not recommended)
+  includeUnsafeEval: false, // Allow 'unsafe-eval' (default: false, not recommended)
 });
 
 console.log(result.header); // Complete CSP header
@@ -114,8 +117,8 @@ const result = generateCSP({
   services: [GoogleAnalytics, Sentry],
   // Development-specific settings
   development: {
-    unsafeEval: true, // Allow eval() in development
-    unsafeInline: true, // Allow inline scripts
+    includeUnsafeEval: true, // Allow eval() in development
+    includeUnsafeInline: true, // Allow inline scripts
   },
   // Production-specific settings
   production: {
@@ -157,15 +160,18 @@ Generate a complete CSP configuration.
 **Options:**
 
 ```typescript
+// Simple array syntax
+generateCSP(services: CSPService[])
+
+// Full options object
 interface CSPOptions {
   services: CSPService[]; // Service objects to include
   nonce?: boolean | string; // Generate/use nonce
   additionalRules?: CSPDirectives; // Additional CSP rules
   reportUri?: string; // CSP violation report URI
-  includeSelf?: boolean; // Include 'self' (default: true)
-  unsafeInline?: boolean; // Allow 'unsafe-inline'
-  unsafeEval?: boolean; // Allow 'unsafe-eval'
-  upgradeInsecureRequests?: boolean; // Upgrade HTTP to HTTPS
+  includeSelf?: boolean; // Include 'self' (default: false)
+  includeUnsafeInline?: boolean; // Allow 'unsafe-inline' (default: false)
+  includeUnsafeEval?: boolean; // Allow 'unsafe-eval' (default: false)
   development?: Partial<CSPOptions>; // Development overrides
   production?: Partial<CSPOptions>; // Production overrides
 }

--- a/packages/generator/src/__tests__/generator.test.ts
+++ b/packages/generator/src/__tests__/generator.test.ts
@@ -40,10 +40,10 @@ describe('generateCSP v2 API', () => {
       expect(result.header).toContain('https://js.stripe.com');
     });
 
-    it('should include self directive by default', () => {
+    it('should not include self directive by default', () => {
       const result = generateCSP([GoogleFonts]);
 
-      expect(result.header).toContain("'self'");
+      expect(result.header).not.toContain("'self'");
     });
   });
 
@@ -93,20 +93,32 @@ describe('generateCSP v2 API', () => {
     it('should handle unsafe directives with warnings', () => {
       const result = generateCSP({
         services: [TestService],
-        unsafeInline: true,
-        unsafeEval: true,
+        includeUnsafeInline: true,
+        includeUnsafeEval: true,
       });
 
       expect(result.header).toContain("'unsafe-inline'");
       expect(result.header).toContain("'unsafe-eval'");
-      expect(result.warnings).toContain("Using 'unsafe-inline' is not recommended for production");
-      expect(result.warnings).toContain("Using 'unsafe-eval' is not recommended for production");
+      expect(result.warnings).toContain(
+        "Using 'unsafe-inline' significantly reduces CSP security. Consider using nonces or hashes instead."
+      );
+      expect(result.warnings).toContain(
+        "Using 'unsafe-eval' reduces security. Avoid eval() and similar constructs."
+      );
     });
 
-    it('should exclude self directive when requested', () => {
+    it('should include self directive when explicitly requested', () => {
       const result = generateCSP({
         services: [TestService],
-        includeSelf: false,
+        includeSelf: true,
+      });
+
+      expect(result.header).toContain("'self'");
+    });
+
+    it('should not include self directive by default', () => {
+      const result = generateCSP({
+        services: [TestService],
       });
 
       expect(result.header).not.toContain("'self'");
@@ -183,8 +195,8 @@ describe('generateCSP v2 API', () => {
       const result = generateCSP({
         services: [TestService],
         development: {
-          unsafeEval: true,
-          unsafeInline: true,
+          includeUnsafeEval: true,
+          includeUnsafeInline: true,
         },
         production: {
           reportUri: '/csp-report',
@@ -205,8 +217,8 @@ describe('generateCSP v2 API', () => {
       const result = generateCSP({
         services: [TestService],
         development: {
-          unsafeEval: true,
-          unsafeInline: true,
+          includeUnsafeEval: true,
+          includeUnsafeInline: true,
         },
         production: {
           reportUri: '/csp-report',

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -32,9 +32,9 @@ export function generateCSP(input: CSPService[] | CSPOptions): CSPResult {
     nonce: nonceOption = false,
     additionalRules = {},
     reportUri,
-    includeSelf = true,
-    unsafeInline = false,
-    unsafeEval = false,
+    includeSelf = false,
+    includeUnsafeInline = false,
+    includeUnsafeEval = false,
     development = {},
     production = {},
   } = options;
@@ -47,8 +47,8 @@ export function generateCSP(input: CSPService[] | CSPOptions): CSPResult {
     additionalRules,
     reportUri,
     includeSelf,
-    unsafeInline,
-    unsafeEval,
+    includeUnsafeInline,
+    includeUnsafeEval,
     development,
     production,
     ...envOptions,
@@ -142,19 +142,21 @@ export function generateCSP(input: CSPService[] | CSPOptions): CSPResult {
   }
 
   // Add unsafe directives if requested (not recommended)
-  if (finalOptions.unsafeInline) {
+  if (finalOptions.includeUnsafeInline) {
     if (mergedDirectives['script-src']) {
       mergedDirectives['script-src'].push("'unsafe-inline'");
     }
     if (mergedDirectives['style-src']) {
       mergedDirectives['style-src'].push("'unsafe-inline'");
     }
-    warnings.push("Using 'unsafe-inline' is not recommended for production");
+    warnings.push(
+      "Using 'unsafe-inline' significantly reduces CSP security. Consider using nonces or hashes instead."
+    );
   }
 
-  if (finalOptions.unsafeEval && mergedDirectives['script-src']) {
+  if (finalOptions.includeUnsafeEval && mergedDirectives['script-src']) {
     mergedDirectives['script-src'].push("'unsafe-eval'");
-    warnings.push("Using 'unsafe-eval' is not recommended for production");
+    warnings.push("Using 'unsafe-eval' reduces security. Avoid eval() and similar constructs.");
   }
 
   // Handle nonce generation

--- a/packages/generator/src/types.ts
+++ b/packages/generator/src/types.ts
@@ -16,14 +16,25 @@ export interface CSPOptions {
   /** Report URI for CSP violations */
   reportUri?: string;
 
-  /** Include 'self' directive by default */
+  /**
+   * Include 'self' directive for common directives
+   * @default false
+   */
   includeSelf?: boolean;
 
-  /** Include 'unsafe-inline' (not recommended) */
-  unsafeInline?: boolean;
+  /**
+   * Include 'unsafe-inline' for script-src and style-src
+   * WARNING: This significantly reduces security. Only use when absolutely necessary.
+   * @default false
+   */
+  includeUnsafeInline?: boolean;
 
-  /** Include 'unsafe-eval' (not recommended) */
-  unsafeEval?: boolean;
+  /**
+   * Include 'unsafe-eval' for script-src
+   * WARNING: This reduces security. Avoid unless required for legacy code.
+   * @default false
+   */
+  includeUnsafeEval?: boolean;
 
   /** Development-specific options */
   development?: Partial<Omit<CSPOptions, 'services' | 'development' | 'production'>>;


### PR DESCRIPTION
## Summary

Simplifies the CSP generation API by replacing abstract security levels with direct boolean flags for better control and intuitive usage.

### Breaking Changes

- **Replaced `securityLevel` with direct boolean flags:**
  - `includeSelf?: boolean` - Include 'self' directive (default: false)
  - `includeUnsafeInline?: boolean` - Allow unsafe-inline (default: false, not recommended)
  - `includeUnsafeEval?: boolean` - Allow unsafe-eval (default: false, not recommended)

- **Changed default behavior:** `includeSelf` now defaults to `false` for more secure CSP generation

### New Features

- **Web App Integration:** Added UI toggles in Advanced Configuration section
- **Better Security:** More secure defaults with explicit opt-in for potentially unsafe directives
- **Intuitive API:** Direct boolean flags instead of abstract security levels

### Changes Made

#### Core Package (`@csp-kit/generator`)
- Updated `CSPOptions` interface with new boolean flags
- Modified generator logic to use new flags with secure defaults
- Updated all tests to verify new behavior

#### Web Application (`apps/web`)
- Added UI toggles for `includeSelf`, `includeUnsafeInline`, and `includeUnsafeEval`
- Integrated toggles with CSP generation pipeline
- Updated usage examples to show new API

#### Documentation & Examples
- Updated all code examples to use new boolean flag API
- Added warnings for unsafe options in UI
- Updated TypeScript definitions and JSDoc comments

### Migration Guide

**Before:**
```typescript
generateCSP({
  services: [GoogleAnalytics],
  securityLevel: 'strict' // or 'balanced', 'legacy'
});
```

**After:**
```typescript
generateCSP({
  services: [GoogleAnalytics],
  includeSelf: false, // explicit control
  includeUnsafeInline: false, // safer by default
  includeUnsafeEval: false // safer by default
});
```

### Test Plan

- [x] All existing tests pass with new API
- [x] Web app toggles correctly affect CSP generation
- [x] New boolean flags work as expected
- [x] Backward compatibility removed as intended
- [x] Lint and type checks pass