### PR TITLE
fix(ci): resolve mixed changeset error blocking release workflow

### DIFF
--- a/.changeset/simplify-csp-api.md
+++ b/.changeset/simplify-csp-api.md
@@ -1,6 +1,5 @@
 ---
 "@csp-kit/generator": minor
-"web": minor
 ---
 
 Simplify CSP API with direct boolean flags

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,30 @@ pnpm changeset
 # 4. GitHub releases are created with changelogs
 ```
 
+**Important Changeset Rules:**
+
+- **NEVER include ignored packages in changesets**: The `web` and `docs` apps are configured as ignored packages and must not be included in changesets
+- **Mixed changesets are not allowed**: A changeset cannot contain both ignored packages (web, docs) and published packages (@csp-kit/\*)
+- When creating a changeset that affects both apps and packages, only include the publishable packages in the changeset
+
+Example of INCORRECT changeset:
+
+```yaml
+---
+'@csp-kit/generator': minor
+'web': minor # ❌ This will cause release to fail!
+---
+```
+
+Example of CORRECT changeset:
+
+```yaml
+---
+'@csp-kit/generator': minor
+# ✅ Omit web/docs even if they have related changes
+---
+```
+
 **Manual release (for specific packages):**
 
 - Go to Actions → Release workflow


### PR DESCRIPTION
## Summary

Fixes the release workflow failure caused by a mixed changeset containing both ignored packages (`web`) and published packages (`@csp-kit/generator`).

## Problem

The release workflow was failing with the error:
```
Found mixed changeset simplify-csp-api
Found ignored packages: web
Found not ignored packages: @csp-kit/generator
Mixed changesets that contain both ignored and not ignored packages are not allowed
```

## Solution

1. **Removed `web` package from the changeset** - Since `web` is configured as an ignored package in `.changeset/config.json`, it should not be included in changesets
2. **Updated CLAUDE.md documentation** - Added clear guidance about changeset rules to prevent this issue in the future

## Changes

- `.changeset/simplify-csp-api.md`: Removed `"web": minor` entry
- `CLAUDE.md`: Added "Important Changeset Rules" section with examples of correct vs incorrect changesets

## Testing

The release workflow should now proceed successfully since the changeset only contains publishable packages.

Fixes https://github.com/eason-dev/csp-kit/actions/runs/16404429274