### PR TITLE
feat(web): improve nonce configuration UI to demonstrate both boolean and string usage

### DIFF
--- a/apps/web/components/csp/usage-methods.tsx
+++ b/apps/web/components/csp/usage-methods.tsx
@@ -17,7 +17,7 @@ import { Label } from '@/components/ui/label';
 interface UsageMethodsProps {
   cspHeader: string;
   serviceIds?: string[];
-  useNonce?: boolean;
+  useNonce?: boolean | string;
   reportUri?: string;
   customRules?: Record<string, string[]>;
   includeSelf?: boolean;
@@ -104,8 +104,13 @@ import { generateCSP } from '@csp-kit/generator';
 import { ${serviceImports || 'GoogleAnalytics, Stripe'} } from '@csp-kit/data';
 
 const result = generateCSP({
-  services: [${serviceImports || 'GoogleAnalytics, Stripe'}],
-  nonce: ${useNonce},${includeSelf ? '\n  includeSelf: true,' : ''}${includeUnsafeInline ? '\n  includeUnsafeInline: true,' : ''}${includeUnsafeEval ? '\n  includeUnsafeEval: true,' : ''}${
+  services: [${serviceImports || 'GoogleAnalytics, Stripe'}],${
+    useNonce === true
+      ? '\n  nonce: true, // Auto-generate unique nonce per request'
+      : useNonce && typeof useNonce === 'string'
+        ? `\n  nonce: '${useNonce}', // Use custom static nonce`
+        : ''
+  }${includeSelf ? '\n  includeSelf: true,' : ''}${includeUnsafeInline ? '\n  includeUnsafeInline: true,' : ''}${includeUnsafeEval ? '\n  includeUnsafeEval: true,' : ''}${
     Object.keys(customRules).length > 0
       ? '\n  additionalRules: {\n' +
         Object.entries(customRules)


### PR DESCRIPTION
## Summary

This PR improves the Generate Nonce option in the web app's Advanced Configuration section to better demonstrate CSP Kit's flexibility in handling both boolean and string nonce values.

### Changes Made

- **Split the single nonce toggle into two distinct options:**
  - **Auto-generate Nonce**: Server generates unique nonce per request (boolean `true`)
  - **Use Custom Nonce**: User provides custom nonce value (string)
  
- **Enhanced UI with better organization:**
  - Created dedicated "Nonce Configuration" section with clear labeling
  - Added descriptive help text for each option
  - Included an input field that appears when "Use Custom Nonce" is selected
  - Made the two options mutually exclusive for clarity
  
- **Updated code generation:**
  - `UsageMethods` component now properly handles both boolean and string nonce values
  - Generated code includes helpful comments explaining nonce behavior
  - NPM package example shows `nonce: true` for auto-generation or `nonce: 'custom-value'` for custom values

### Visual Changes

- Accordion header badges now show "Auto Nonce" or "Custom Nonce" to indicate which option is active
- Custom nonce input field is pre-filled with a sample value when first enabled
- Better visual hierarchy with proper indentation and borders

### Why This Change?

The previous implementation only showed a boolean toggle, which didn't demonstrate that CSP Kit also supports custom string nonce values. This improvement provides clearer guidance for users on when to use each approach:
- Auto-generate (boolean): Recommended for dynamic applications where the server generates unique nonces
- Custom value (string): Useful for testing, static sites, or when integrating with existing nonce systems

## Test plan

- [x] Verified both auto-generate and custom nonce options work correctly
- [x] Confirmed mutually exclusive behavior (selecting one deselects the other)
- [x] Tested generated code examples show correct nonce configuration
- [x] Checked that the CSP header is generated correctly with both nonce types
- [x] Ensured no breaking changes to existing functionality